### PR TITLE
[CHORE] 윈도우/맥 OS간 줄바꿈 충돌 방지

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+text=auto eol=lf
 /gradlew text eol=lf
 *.bat text eol=crlf
 *.jar binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-text=auto eol=lf
+* text=auto eol=lf
 /gradlew text eol=lf
 *.bat text eol=crlf
 *.jar binary


### PR DESCRIPTION
Windows(CRLF)랑 Mac/Linux(LF) 혼용 팀에서 줄바꿈 차이로 생기는 불필요한 diff가 제거

## Issue number
- close #30 
## Check list
- [ ] 테스트 통과 확인
- [ ] 모든 commit이 push 확인
- [ ] merge branch 확인


## (Optional) Additional description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 저장소에 텍스트 처리 규칙을 추가하여 파일의 줄바꿈을 LF로 일관화하고 파일 처리의 일관성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->